### PR TITLE
Feature: Implement Ctrl+W/Ctrl+Backspace to delete last word

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -36,7 +36,7 @@ pub struct Tukai<'a> {
   is_terminated: bool,
 
   // Displayed screen (typing|stats)
-  screen: Box<dyn Screen>
+  screen: Box<dyn Screen>,
 }
 
 impl<'a> Tukai<'a> {
@@ -75,7 +75,7 @@ impl<'a> Tukai<'a> {
 
       is_terminated: false,
 
-      screen: Box::new(typing_screen)
+      screen: Box::new(typing_screen),
     })
   }
 
@@ -147,7 +147,7 @@ impl<'a> Tukai<'a> {
     match switch_to_screen {
       ActiveScreenEnum::Stats => {
         self.screen = Box::new(StatsScreen::new(self.config.clone()));
-      },
+      }
       ActiveScreenEnum::Typing => {
         self.screen = Box::new(TypingScreen::new(self.config.clone()));
       }
@@ -198,8 +198,18 @@ impl<'a> Tukai<'a> {
             self.storage_handler.set_language_index(new_language_index);
             self.reset();
           }
+          'w' => {
+            if let Some(typing_screen) = self.screen.as_typing_screen_mut() {
+              typing_screen.delete_last_word();
+            }
+          }
           _ => {}
         },
+        KeyCode::Backspace => {
+          if let Some(typing_screen) = self.screen.as_typing_screen_mut() {
+            typing_screen.delete_last_word();
+          }
+        }
         _ => {}
       }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -161,6 +161,11 @@ impl<'a> Tukai<'a> {
   /// Finally, processes remainig keys.
   fn handle_events(&mut self, key_event: KeyEvent) {
     if key_event.modifiers.contains(KeyModifiers::CONTROL) {
+      // Handle screen specific CTRL key events
+      if self.screen.handle_control_events(key_event) {
+        return;
+      }
+
       match key_event.code {
         KeyCode::Char(c) => match c {
           'r' => self.reset(),
@@ -198,18 +203,8 @@ impl<'a> Tukai<'a> {
             self.storage_handler.set_language_index(new_language_index);
             self.reset();
           }
-          'w' => {
-            if let Some(typing_screen) = self.screen.as_typing_screen_mut() {
-              typing_screen.delete_last_word();
-            }
-          }
           _ => {}
         },
-        KeyCode::Backspace => {
-          if let Some(typing_screen) = self.screen.as_typing_screen_mut() {
-            typing_screen.delete_last_word();
-          }
-        }
         _ => {}
       }
 

--- a/src/screens.rs
+++ b/src/screens.rs
@@ -15,7 +15,6 @@ use ratatui::{
 
 use crate::{
   config::{TukaiConfig, TukaiLayout, TukaiLayoutColorTypeEnum},
-  screens::typing_screen::TypingScreen as TypinngScreenType,
   storage::storage_handler::StorageHandler,
 };
 
@@ -179,8 +178,11 @@ pub trait Screen {
   /// Used after the run is completed
   fn render_popup(&self, frame: &mut Frame);
 
-  // Allows downcasting to a mutable TypingScreen if applicable.
-  fn as_typing_screen_mut(&mut self) -> Option<&mut TypinngScreenType> {
-    None
+  /// Handles control-modified key events specific to the screen.
+  ///
+  /// True if event consumed, false otherwise.
+  #[allow(unused_variables)]
+  fn handle_control_events(&mut self, key_event: KeyEvent) -> bool {
+    false
   }
 }

--- a/src/screens.rs
+++ b/src/screens.rs
@@ -13,7 +13,11 @@ use ratatui::{
   Frame,
 };
 
-use crate::{config::{TukaiConfig, TukaiLayout, TukaiLayoutColorTypeEnum}, storage::storage_handler::StorageHandler};
+use crate::{
+  config::{TukaiConfig, TukaiLayout, TukaiLayoutColorTypeEnum},
+  screens::typing_screen::TypingScreen as TypinngScreenType,
+  storage::storage_handler::StorageHandler,
+};
 
 #[allow(unused)]
 pub trait ToDark {
@@ -174,4 +178,9 @@ pub trait Screen {
   ///
   /// Used after the run is completed
   fn render_popup(&self, frame: &mut Frame);
+
+  // Allows downcasting to a mutable TypingScreen if applicable.
+  fn as_typing_screen_mut(&mut self) -> Option<&mut TypinngScreenType> {
+    None
+  }
 }

--- a/src/screens/typing_screen.rs
+++ b/src/screens/typing_screen.rs
@@ -165,8 +165,18 @@ impl Screen for TypingScreen {
     String::from("Typing")
   }
 
-  fn as_typing_screen_mut(&mut self) -> Option<&mut TypingScreen> {
-    Some(self)
+  fn handle_control_events(&mut self, key_event: KeyEvent) -> bool {
+    if self.is_popup_visible {
+      return false;
+    }
+
+    match key_event.code {
+      KeyCode::Char('w') | KeyCode::Backspace => {
+        self.delete_last_word();
+        true
+      }
+      _ => false,
+    }
   }
 
   /// Resets all necessary properties

--- a/src/screens/typing_screen.rs
+++ b/src/screens/typing_screen.rs
@@ -165,6 +165,10 @@ impl Screen for TypingScreen {
     String::from("Typing")
   }
 
+  fn as_typing_screen_mut(&mut self) -> Option<&mut TypingScreen> {
+    Some(self)
+  }
+
   /// Resets all necessary properties
   fn reset(&mut self) {
     self.is_running = false;
@@ -385,6 +389,42 @@ impl TypingScreen {
     }
   }
 
+  // Deletes the last word form the input.
+  // Handles trailing spaces and updates mistakes.
+  pub fn delete_last_word(&mut self) {
+    if self.input.is_empty() {
+      return;
+    }
+
+    let original_input_len = self.input.len();
+
+    // Find the end of the actual contnet (trim trailing whitespace for logic)
+    let trimmed_end_len = self.input.trim_end().len();
+
+    if trimmed_end_len == 0 {
+      // Input was all spaces
+      for i in 0..original_input_len {
+        self.mistake_handler.remove_from_mistakes_indexes(i);
+      }
+      self.input.clear();
+      self.cursor_index = 0;
+      return;
+    }
+
+    // Find the last space before the last word in the trimmed part
+    let last_word_start_idx = match self.input[..trimmed_end_len].rfind(' ') {
+      Some(space_idx) => space_idx + 1, // Word starts after the space
+      None => 0,                        // No space found, word starts at the beginning
+    };
+
+    for i in last_word_start_idx..original_input_len {
+      self.mistake_handler.remove_from_mistakes_indexes(i);
+    }
+
+    self.input.truncate(last_word_start_idx);
+    self.cursor_index = self.input.len();
+  }
+
   /// Returns the raw WPM
   pub fn get_calculated_raw_wpm(&self) -> usize {
     if let Some(last_stat) = &self.stat {
@@ -420,7 +460,11 @@ impl TypingScreen {
 
     let (primary_color, error_color, text_color) = {
       let colors = {
-        (layout.get_primary_color(), layout.get_error_color(), layout.get_text_color())
+        (
+          layout.get_primary_color(),
+          layout.get_error_color(),
+          layout.get_text_color(),
+        )
       };
 
       if self.is_popup_visible() {


### PR DESCRIPTION
Added the functionality to delete last typed word in the `TypingScreen` using the `Ctrl+W` and `Ctrl+Backspace` shortcuts.

- Added `delete_last_word` method to `TypingScreen`.
- Modified `Screen` trait with `as_typing_screen_mut`.
- Updated `app.rs` with correct shortcuts.

Closes #11

**Note on tests**:
Currently, there are some tests that are not passing, however I have confirmed that those have existed before my changes.