### PR TITLE
fix: correct occured to occurred typo in error messages

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -126,7 +126,7 @@ impl<'a> Tukai<'a> {
     self
       .storage_handler
       .flush()
-      .expect("Error occured while saving into the file");
+      .expect("Error occurred while saving into the file");
   }
 
   /// Switches active `screen`.

--- a/src/storage/storage_handler.rs
+++ b/src/storage/storage_handler.rs
@@ -294,7 +294,7 @@ mod tests {
 
     storage_handler
       .delete_file()
-      .expect("Error occured while deleting file");
+      .expect("Error occurred while deleting file");
   }
 
   #[test]
@@ -310,7 +310,7 @@ mod tests {
 
     assert!(
       storage_handler.insert_into_stats(&stat),
-      "Insert into the storage error occured"
+      "Insert into the storage error occurred"
     );
 
     let _stats = storage_handler.get_data_stats_reversed();
@@ -328,7 +328,7 @@ mod tests {
     //
     // storage_handler
     //   .delete_file()
-    //   .expect("Error occured while deleting file");
+    //   .expect("Error occurred while deleting file");
   }
 
   #[test]
@@ -340,7 +340,7 @@ mod tests {
 
     storage_handler
       .delete_file()
-      .expect("Error occured while deleting file");
+      .expect("Error occurred while deleting file");
   }
 
   #[test]
@@ -355,6 +355,6 @@ mod tests {
 
     storage_handler
       .delete_file()
-      .expect("Error occured while deleting file");
+      .expect("Error occurred while deleting file");
   }
 }


### PR DESCRIPTION
Hi @hlsxx 👋 Thanks for maintaining tukai!

This PR fixes a simple typo: `occured` → `occurred` in error messages (6 occurrences across 2 files).

Files:
- src/storage/storage_handler.rs: 5 fixes (including 1 comment)
- src/app.rs: 1 fix

2 files, 6 lines. Happy to make any adjustments if needed! 🙏